### PR TITLE
Fix firing issue

### DIFF
--- a/HumanControls/HumanControls.cpp
+++ b/HumanControls/HumanControls.cpp
@@ -75,7 +75,6 @@ void HumanControls::update(uint8_t *messageBuffer)
 
 void HumanControls::setStatus()
 {
-
     if (m_payload.getStatus() != Utils::ControllerStatus::DISCONNECTED)
     {
         if (m_payload.getError() == 0)
@@ -85,7 +84,15 @@ void HumanControls::setStatus()
             // set both statuses to disabled. Robot status and controller status should always be the same.
             // Only exception may be due to firing setting status to enabled after firing.
 
-            if (m_enableController.getIsEnabled())
+            // Send an extra payload with the FIRING status
+            // This is to ensure we aren't missing the signal to fire on the robot side
+            if (!m_hasSentSecondFirePayload) 
+            {
+                status = Utils::ControllerStatus::FIRING;
+                m_hasSentSecondFirePayload = true;
+                Serial.println("Extra firing payload");
+            }
+            else if (m_enableController.getIsEnabled())
             {
                 if (m_fireController.getIsPrimed())
                 {
@@ -159,6 +166,7 @@ void HumanControls::onPinActivated(int pinNr)
             m_fireController.initiateFiring(true);
             m_fireController.setIsPrimed(false);
             m_payload.setStatus(Utils::ControllerStatus::FIRING);
+            m_hasSentSecondFirePayload = false;
         }
     }
 }

--- a/HumanControls/HumanControls.h
+++ b/HumanControls/HumanControls.h
@@ -49,6 +49,8 @@ public:
 private:
     void setError(const char *format, ...);
 
+    bool m_hasSentSecondFirePayload;
+
     int m_encoderPinSW, m_enablePin, m_primePin, m_firePin;
     static Utils::ControllerStatus lastStatus;
 

--- a/RobotControl/LinearActuator.cpp
+++ b/RobotControl/LinearActuator.cpp
@@ -88,5 +88,4 @@ void LinearActuator::stop()
   m_currentDirection = STOP;
   m_lastMillis = 0;
   m_actuator.write(STOP_WRITE_VALUE);
-  Serial.println("Stopping...");
 }

--- a/RobotControl/Robot.cpp
+++ b/RobotControl/Robot.cpp
@@ -77,11 +77,11 @@ void Robot::update()
     setError("Tick %d ms", tickDurationMillis);
   }
 
-  int timeLeftMillis = TICK_DURATION_MILLIS - (millis() - tickStartMillis);
-  if (timeLeftMillis > 0)
-  {
+  // int timeLeftMillis = TICK_DURATION_MILLIS - (millis() - tickStartMillis);
+  // if (timeLeftMillis > 0)
+  // {
     // delay(timeLeftMillis);
-  }
+  // }
 }
 
 void Robot::updateSerial()
@@ -105,31 +105,6 @@ void Robot::updatePayload(const uint8_t *data, const uint8_t len)
 
   const uint8_t status = m_payload.getStatus();
   const uint8_t err = m_payload.getError();
-
-  if (err > 0 || !success)
-  {
-    m_statusLEDs.setBlinkPattern(StatusLEDs::ERROR);
-    m_payload.setStatus(STATUS_DISABLED);
-  }
-  else
-  {
-    if (status == STATUS_DISABLED)
-    {
-      m_statusLEDs.setBlinkPattern(StatusLEDs::DISABLED);
-    }
-    else if (status == STATUS_ENABLED)
-    {
-      m_statusLEDs.setBlinkPattern(StatusLEDs::ENABLED);
-    }
-    else if (status == STATUS_PRIMED)
-    {
-      m_statusLEDs.setBlinkPattern(StatusLEDs::PRIMED);
-    }
-    else
-    {
-      m_statusLEDs.setBlinkPattern(StatusLEDs::OFF);
-    }
-  }
 }
 
 void Robot::setRobot()
@@ -151,6 +126,7 @@ void Robot::setRobot()
   {
     digitalWrite(m_fireSolenoidPin, LOW);
     m_firing = false;
+    digitalWrite(LED_BUILTIN, LOW);
   }
 
   if (status != STATUS_ENABLED)
@@ -164,6 +140,7 @@ void Robot::setRobot()
     digitalWrite(m_fireSolenoidPin, LOW);
     m_firing = false;
     m_isHoldingFire = false;
+    digitalWrite(LED_BUILTIN, LOW);
   }
 
   if (status == STATUS_ENABLED)
@@ -181,6 +158,7 @@ void Robot::setRobot()
       m_solenoidCloseMillis = millis() + m_fireTimeMillis;
       m_firing = true;
       m_isHoldingFire = true;
+      digitalWrite(LED_BUILTIN, HIGH);
     }
   }
 

--- a/RobotControl/RobotControl.ino
+++ b/RobotControl/RobotControl.ino
@@ -18,7 +18,7 @@
 #define PIN_LED_BUILTIN LED_BUILTIN
 #define FIRE_SOLENOID_PIN 3
 
-#define ANGLE_IN 11
+#define ANGLE_INPUT 11
 
 // 0.00067 = in/per 
 // 8,955.22388 = milliseconds to max travel


### PR DESCRIPTION
Robot was not firing consistently due to missing the singular payload with the FIRING status
Ideally we would make it so that there no missed payloads but we have a home game today.

Updated the controller to send 2 back to back payloads with the FIRING status to ensure that the robot would pick up on one of them.